### PR TITLE
updated dockerfile to install necessary python3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM jrottenberg/ffmpeg:5-ubuntu
 RUN apt update \
-    && apt install python3 python3-pip --no-install-recommends -y \
+    && apt install curl python3.9 python3.9-distutils --no-install-recommends -y \
     && rm /var/lib/apt/lists/*.lz4
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.9 get-pip.py \
+    && rm get-pip.py \
+    && apt remove curl -y
 
-RUN pip install twitch-archiver
+RUN pip3.9 install twitch-archiver
 
 ENTRYPOINT [ "twitch-archiver" ]


### PR DESCRIPTION
hey,

wanted to run this in a docker container with the provided Dockerfile but it didn't work due to wrong python-version being installed in the Dockerfile.

Running twitch-archiver in the container gave me:
`Traceback (most recent call last):
  File "/usr/local/bin/twitch-archiver", line 5, in <module>
    from twitcharchiver.__init__ import main
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/__init__.py", line 40, in <module>
    from twitcharchiver.channel import Channel
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/channel.py", line 10, in <module>
    from twitcharchiver.api import Api
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/api.py", line 9, in <module>
    from twitcharchiver.exceptions import (
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/exceptions.py", line 10, in <module>
    from twitcharchiver.utils import get_temp_dir
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/utils.py", line 20, in <module>
    from twitcharchiver.twitch import Chapters
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/twitch.py", line 82, in <module>
    class Chapters:
  File "/usr/local/lib/python3.8/dist-packages/twitcharchiver/twitch.py", line 88, in Chapters
    def __init__(self, moments: list[dict] = None):
TypeError: 'type' object is not subscriptable`

**Affected Line:**
`def __init__(self, moments: list[dict] = None):`

**Description:**
https://docs.python.org/3.9/whatsnew/3.9.html#type-hinting-generics-in-standard-collections

**Change:**
Installing python **v3.9** instead of **v3.8.10** (ubuntu default)