### PR TITLE
fix: derive per-VOD output directory from channel in vod_downloader

### DIFF
--- a/tests/unit/test_processing.py
+++ b/tests/unit/test_processing.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import patch
+
+from twitcharchiver.channel import Channel
+from twitcharchiver.processing import Processing
+from twitcharchiver.vod import ArchivedVod
+
+
+class TestProcessing(unittest.TestCase):
+    def _minimal_conf(self, directory: str = "/tmp/test") -> dict:
+        return {
+            "quiet": True,
+            "chat": True,
+            "video": True,
+            "archive_only": False,
+            "highlights": False,
+            "live_only": False,
+            "real_time_archiver": False,
+            "unsorted": True,
+            "config_dir": "/tmp",
+            "directory": directory,
+            "discord_webhook": "",
+            "pushbullet_key": "",
+            "quality": "best",
+            "threads": 1,
+            "force_no_archive": False,
+        }
+
+    @staticmethod
+    def _fake_channel(name: str) -> Channel:
+        channel = Channel.__new__(Channel)
+        channel.id = 123
+        channel.name = name
+        channel.display_name = name
+        channel.stream = None
+        channel._broadcast_v_id = 0
+        channel._last_update = 0
+        channel._api = None
+        channel._log = None
+        return channel
+
+    def _fake_vod(self, v_id: int, channel_name: str) -> ArchivedVod:
+        vod = ArchivedVod()
+        vod.v_id = v_id
+        vod._s_id = 0
+        vod.title = "Test"
+        vod.created_at = 0
+        vod.duration = 100
+        vod.type = "ARCHIVE"
+        vod.video_archived = False
+        vod.chat_archived = False
+        vod.channel = self._fake_channel(channel_name)
+        return vod
+
+    @patch("twitcharchiver.processing.Database")
+    def test_vod_downloader_uses_channel_specific_directories(self, mock_db):
+        """
+        Verify that when vod_downloader() receives VODs from multiple channels,
+        each downloader is passed its own channel-specific output directory.
+        """
+        conf = self._minimal_conf(directory="/data/parent")
+        process = Processing(conf)
+
+        queue = [
+            self._fake_vod(1, "channelA"),
+            self._fake_vod(2, "channelB"),
+            self._fake_vod(3, "channelA"),
+        ]
+
+        with patch("twitcharchiver.processing.Video") as mock_video, \
+             patch("twitcharchiver.processing.Chat") as mock_chat, \
+             patch.object(process, "_start_download"), \
+             patch.object(ArchivedVod, "is_live", return_value=False), \
+             patch.object(Channel, "is_live", return_value=False):
+            process.vod_downloader(queue)
+
+        video_calls = [call.args for call in mock_video.call_args_list]
+        chat_calls = [call.args for call in mock_chat.call_args_list]
+
+        # Video / Chat constructors receive (vod, parent_dir, ...)
+        video_dirs = [str(args[1]) for args in video_calls]
+        chat_dirs = [str(args[1]) for args in chat_calls]
+
+        self.assertEqual(
+            video_dirs,
+            ["/data/parent/channelA", "/data/parent/channelB", "/data/parent/channelA"],
+        )
+        self.assertEqual(
+            chat_dirs,
+            ["/data/parent/channelA", "/data/parent/channelB", "/data/parent/channelA"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/twitcharchiver/processing.py
+++ b/twitcharchiver/processing.py
@@ -250,6 +250,9 @@ class Processing:
         for _vod in download_queue:
             self.log.debug("Processing VOD %s from download queue.", _vod.v_id)
 
+            # derive per-VOD output directory from channel rather than stale shared state
+            _vod_output_dir = Path(self._parent_dir, _vod.channel.name) if _vod.channel.name else self.output_dir
+
             if _vod.channel not in _channel_cache:
                 self.log.debug(
                     "Channel '%s' missing from cache - adding now.", _vod.channel
@@ -280,7 +283,7 @@ class Processing:
                         self.log.debug("Archiving VOD with `real-time` archiver.")
                         _real_time_archiver = RealTime(
                             _vod,
-                            self.output_dir,
+                            _vod_output_dir,
                             self.archive_chat,
                             self.quality,
                             self.threads,
@@ -294,7 +297,7 @@ class Processing:
                     _video_download_queue.append(
                         Highlight(
                             _vod,
-                            self.output_dir,
+                            _vod_output_dir,
                             self.quality,
                             self.threads,
                             self.quiet,
@@ -305,7 +308,7 @@ class Processing:
                     _video_download_queue.append(
                         Video(
                             _vod,
-                            self.output_dir,
+                            _vod_output_dir,
                             self.quality,
                             self.threads,
                             self.quiet,
@@ -314,7 +317,7 @@ class Processing:
 
             if not _vod.chat_archived and self.archive_chat:
                 self.log.debug("Adding VOD to chat archive queue.")
-                _chat_download_queue.append(Chat(_vod, self.output_dir, self.quiet))
+                _chat_download_queue.append(Chat(_vod, _vod_output_dir, self.quiet))
 
         for _downloader in _video_download_queue:
             self._start_download(_downloader)


### PR DESCRIPTION
Previously, vod_downloader() used self.output_dir for all VODs in the download queue. Because get_channel() sets self.output_dir to each channel's subdirectory while looping, by the time vod_downloader() runs self.output_dir contains the *last* channel's folder. This caused all VODs from multiple channels to be written into a single directory.

Now vod_downloader() derives the output directory for each VOD from _vod.channel.name, ensuring each channel's VODs go into their own subdirectory.

Includes a regression test to verify Video and Chat downloaders receive the correct channel-specific paths when processing a mixed channel queue.